### PR TITLE
Add typescript example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Find and remove unused es6 modules
 
 If running [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) please use the `-ts`
 extension on your rules to make this also leverage type information (otherwise the autofixer will remove
-imports only used for type information).
+imports only used for type information). There is an example in the Usage section below.
 
 ## Installation
 
@@ -44,6 +44,18 @@ e.g.
 		"no-unused-vars": "off",
 		"unused-imports/no-unused-imports": 2,
 		"unused-imports/no-unused-vars": 1
+	}
+}
+```
+
+Or, if using TypeScript:
+
+```json
+{
+	"rules": {
+		"@typescript-eslint/no-unused-vars": "off",
+		"unused-imports/no-unused-imports-ts": 2,
+		"unused-imports/no-unused-vars-ts": 1
 	}
 }
 ```


### PR DESCRIPTION
Hello, I like your project idea. ⭐️ I wanted to try this plugin with typescript-eslint, so the first thing I had to do was translate the code example to work with typescript-eslint. Maybe including an example for Typescript would make it easier for people to copy and paste into TypeScript projects? I know this project does not really have pull requests so if you do not feel comfortable accepting pull requests from others please don't feel pressured in any way. Thanks.