### PR TITLE
Remove trailing comma from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then configure the rules you want to use under the rules section. I can recommen
   "unused-imports/no-unused-imports": "error",
   "unused-imports/no-unused-vars": [
    "warn",
-   { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" },
+   { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
   ],
  }
 }
@@ -62,7 +62,7 @@ Or, if using TypeScript:
   "unused-imports/no-unused-imports-ts": "error",
   "unused-imports/no-unused-vars-ts": [
    "warn",
-   { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" },
+   { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
   ],
  }
 }


### PR DESCRIPTION
I copied the config from the README into my `.eslintrc.json` file and got the following error:

> Cannot read config file: .eslintrc.json
> Error: Unexpected token ] 

I ran into this error because the config from the README includes a trailing comma which is not valid in JSON syntax. Removing the trailing comma from the options object will prevent others from running into the same error. 🙂