### PR TITLE
Fix docs links in rule metadata

### DIFF
--- a/docs/rules/no-unused-imports.md
+++ b/docs/rules/no-unused-imports.md
@@ -1,3 +1,3 @@
 # Do not allow unused imports (no-unused-imports)
 
-A rule to find unused-imports only as well as an autofixer.
+A rule to find unused-imports only, as well as an autofixer.

--- a/lib/rules/no-unused-imports.js
+++ b/lib/rules/no-unused-imports.js
@@ -19,5 +19,6 @@ try {
 
 rule.meta.fixable = "code";
 rule.meta.docs.url = "https://github.com/sweepline/eslint-plugin-unused-imports/blob/master/docs/rules/no-unused-imports.md";
+rule.meta.docs.extendsBaseRule = false;
 
 module.exports = ruleComposer.filterReports(rule, unusedImportsPredicate);

--- a/lib/rules/no-unused-imports.js
+++ b/lib/rules/no-unused-imports.js
@@ -18,5 +18,6 @@ try {
 }
 
 rule.meta.fixable = "code";
+rule.meta.docs.url = "https://github.com/sweepline/eslint-plugin-unused-imports/blob/master/docs/rules/no-unused-imports.md";
 
 module.exports = ruleComposer.filterReports(rule, unusedImportsPredicate);

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -18,5 +18,6 @@ try {
 }
 
 rule.meta.fixable = "code";
+rule.meta.docs.url = "https://github.com/sweepline/eslint-plugin-unused-imports/blob/master/docs/rules/no-unused-vars.md";
 
 module.exports = ruleComposer.filterReports(rule, unusedVarsPredicate);


### PR DESCRIPTION
Hey there 🙂
While adding these rules to my eslint-config, I noticed that the docs urls point to the base docs.
This fixes that 👍