### PR TITLE
Don't delete comments when deleting last import

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.1.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug current test file",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["test", "--testPathPattern", "${file}", "--coverage", "false"],
+      "port": 9229,
+      "cwd": "${fileDirname}",
+      "timeout": 10000,
+      "console": "integratedTerminal"
+    }
+  ]
+}
+

--- a/lib/__test__/no-unused-imports.test.js
+++ b/lib/__test__/no-unused-imports.test.js
@@ -1,0 +1,97 @@
+const rule = require("../rules/no-unused-imports");
+RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015, sourceType: "module", } });
+
+ruleTester.run("no-unused-imports", rule, {
+	valid: [
+		{
+			code: `
+import x from "package";
+import { a, b } from "./utils";
+import y from "package";
+
+const c = a() + b + x() + y();
+`,
+		}
+	],
+
+	invalid: [
+		{
+			code: `
+import x from "package";
+import { a, b } from "./utils";
+import y from "package";
+
+const c = b(x, y);
+`,
+			errors: ["'a' is defined but never used."],
+			output: `
+import x from "package";
+import { b } from "./utils";
+import y from "package";
+
+const c = b(x, y);
+`
+		},
+		{
+			code: `
+import { a, b } from "./utils";
+import y from "package";
+
+/**
+ * this is a jsdoc!
+ */
+const c = a(y);
+`,
+			errors: ["'b' is defined but never used."],
+			output: `
+import { a } from "./utils";
+import y from "package";
+
+/**
+ * this is a jsdoc!
+ */
+const c = a(y);
+`
+		},
+		{
+			code: `
+import { a } from "./utils";
+import y from "package";
+
+const c = 4;
+console.log(y);
+`,
+			errors: ["'a' is defined but never used."],
+			output: `
+import y from "package";
+
+const c = 4;
+console.log(y);
+`
+		},
+		{
+			code: `
+import y from "package";
+import { a } from "./utils";
+
+/**
+ * c is the number 4
+ */
+const c = 4;
+console.log(y);
+`,
+			errors: ["'a' is defined but never used."],
+			output: `
+import y from "package";
+
+/**
+ * c is the number 4
+ */
+const c = 4;
+console.log(y);
+`
+		}
+	]
+});

--- a/lib/rules/predicates.js
+++ b/lib/rules/predicates.js
@@ -19,6 +19,7 @@ exports.unusedVarsPredicate = (problem, context) => {
 };
 
 const commaFilter = { filter: (token) => token.value === "," };
+const includeCommentsFilter = { includeComments: true };
 
 exports.unusedImportsPredicate = (problem, context) => {
 	const { sourceCode } = context;
@@ -53,7 +54,7 @@ exports.unusedImportsPredicate = (problem, context) => {
 
 		// Only one import
 		if (grandParent.specifiers.length === 1) {
-			const nextToken = sourceCode.getTokenAfter(grandParent);
+			const nextToken = sourceCode.getTokenAfter(grandParent, includeCommentsFilter);
 			const newLinesBetween = nextToken ? nextToken.loc.start.line - grandParent.loc.start.line : 0;
 			const endOfReplaceRange = nextToken ? nextToken.range[0] : grandParent.range[1]
 			const count = Math.max(0, newLinesBetween - 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -925,22 +925,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/eslint": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
-      "integrity": "sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,263 @@
         "@babel/highlight": "^7.12.13"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.14.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/compat-data/-/compat-data-7.14.7.tgz",
+      "integrity": "sha1-ewR9ejqJpn0iWNxh9gTwmPG8fgg=",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/core/-/core-7.14.8.tgz",
+      "integrity": "sha1-IM33yEtdhtg/rIcQqLxgWnuj8BA=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.8",
+        "@babel/helper-compilation-targets": "^7.14.5",
+        "@babel/helper-module-transforms": "^7.14.8",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.14.8",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha1-Mr4zp1bynieKDWRPoIosng+Io0w=",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/generator/-/generator-7.14.8.tgz",
+      "integrity": "sha1-v4b9avls87dDlajKQJUV+JQj4HA=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.8",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+      "integrity": "sha1-epnF0JZ5Eely/iw0EffVtJhJjs8=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha1-ieLEdJcvFdjiM7Uu6MSA4s/NUMQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha1-Jfv6V5sJN+7h87gF7OTOOYxDGBU=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+      "integrity": "sha1-4N0nwzp45XfXyIhJFqPn7x98f40=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.14.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+      "integrity": "sha1-l+ViRL65QhH+J3vYGOOjKcZveXA=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha1-bRpE32o4yVeqfDEtoHZCnxG0IvM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
+      "integrity": "sha1-1Ceffj/V9NXTQtgzrzbU3YfX3Ek=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5",
+        "@babel/helper-simple-access": "^7.14.8",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha1-Mr4zp1bynieKDWRPoIosng+Io0w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha1-8nOVqGGeBmWz8DZM3bQcJdcbSZw=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha1-WsgizpfuxGdBq3ClF5ceRDpwxak=",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+      "integrity": "sha1-DswLA8Qc1We0Ak6gFhNMKEFKu5Q=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.14.5",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha1-guH+wGRKfndcdNMF8hLDn4/nOSQ=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.8"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha1-IrI6VO9RwrdgXYUZMMGXbdC8aTo=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM=",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helpers/-/helpers-7.14.8.tgz",
+      "integrity": "sha1-g5+I9GMCWIbP9/haNSlwB+LaG3c=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.8",
+        "@babel/types": "^7.14.8"
+      }
     },
     "@babel/highlight": {
       "version": "7.12.13",
@@ -43,6 +295,265 @@
         }
       }
     },
+    "@babel/parser": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/parser/-/parser-7.14.8.tgz",
+      "integrity": "sha1-Zv1BZmste4QL1azn90FtWsYCCNQ=",
+      "dev": true
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha1-uCxs5HGxZbXOQgz5KRTW+0YiVxY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/template": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha1-qbydizM1T/blWpxg0RCSAKaJdPQ=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha1-Mr4zp1bynieKDWRPoIosng+Io0w=",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/traverse/-/traverse-7.14.8.tgz",
+      "integrity": "sha1-wCU/Amd8XeGo/532sKrL7H2hqM4=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.8",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.14.8",
+        "@babel/types": "^7.14.8",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha1-I7CNdA6D9JxeWZRfvxtD6Au/Tts=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha1-Mr4zp1bynieKDWRPoIosng+Io0w=",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.14.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/types/-/types-7.14.8.tgz",
+      "integrity": "sha1-OBCd6PytwGQV+9m3TfAGXU1Bxyg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.8",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha1-Mr4zp1bynieKDWRPoIosng+Io0w=",
+          "dev": true
+        }
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -67,6 +578,260 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         }
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/console/-/console-27.0.6.tgz",
+      "integrity": "sha1-PrcuqAiXSVw9c92XqrfyZ3DiJg8=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/core/-/core-27.0.6.tgz",
+      "integrity": "sha1-xfZCcnoLO/DzfEtGxnU3LQl41KE=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^27.0.6",
+        "@jest/reporters": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.8.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-changed-files": "^27.0.6",
+        "jest-config": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-resolve-dependencies": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "jest-watcher": "^27.0.6",
+        "micromatch": "^4.0.4",
+        "p-each-series": "^2.1.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/environment/-/environment-27.0.6.tgz",
+      "integrity": "sha1-7ik/6ZbbAdfWY7gQj6Dh/0NiGdI=",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "jest-mock": "^27.0.6"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/fake-timers/-/fake-timers-27.0.6.tgz",
+      "integrity": "sha1-y61S8/5qvjDnrLjNX6NGa5WI498=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "@sinonjs/fake-timers": "^7.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
+      }
+    },
+    "@jest/globals": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/globals/-/globals-27.0.6.tgz",
+      "integrity": "sha1-SOOQP5mkZQZz2GVzNNE8nK8Oj4I=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "expect": "^27.0.6"
+      }
+    },
+    "@jest/reporters": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/reporters/-/reporters-27.0.6.tgz",
+      "integrity": "sha1-kefy2YwAKtXflNW1FnwesLn9WwA=",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^8.0.0"
+      }
+    },
+    "@jest/source-map": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/source-map/-/source-map-27.0.6.tgz",
+      "integrity": "sha1-vp6bk1ZdSbBUi4biMgkkkftgVR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.4",
+        "source-map": "^0.6.0"
+      }
+    },
+    "@jest/test-result": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/test-result/-/test-result-27.0.6.tgz",
+      "integrity": "sha1-P6QgFaFOT97eas0ELOmMfzZicFE=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz",
+      "integrity": "sha1-gKkT7XoRMFRbHNd3/yc13Tr100s=",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^27.0.6",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.6",
+        "jest-runtime": "^27.0.6"
+      }
+    },
+    "@jest/transform": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/transform/-/transform-27.0.6.tgz",
+      "integrity": "sha1-GJrXEHQTII92APRxn4HdL3J4zJU=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^27.0.6",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@jest/types/-/types-27.0.6.tgz",
+      "integrity": "sha1-mpkrxRfgxJ8DWTi4VJcZwt5AcGs=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -95,6 +860,71 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha1-OALd0hpQqUm2ch3dcto25n5/Gy0=",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha1-JSTq5wxJEO3M+ZsvTm78WJSv97U=",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+      "dev": true
+    },
+    "@types/babel__core": {
+      "version": "7.1.15",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/babel__core/-/babel__core-7.1.15.tgz",
+      "integrity": "sha1-LM+xrVWgLIP44K0yfLwzL1XrECQ=",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha1-9Fa0ss55E392iqEw0kI9LwzPq6U=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha1-PRpI/Z1sDt/Vby/1eNrtSPNsiWk=",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.14.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha1-/81HC7s/i/MEgWePtVAieMqDOkM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
     "@types/eslint": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
@@ -111,6 +941,39 @@
       "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
       "dev": true
     },
+    "@types/graceful-fs": {
+      "version": "4.1.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+      "integrity": "sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha1-S6jdtyAiH0MuRDvV+RF/0iz9R2I=",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-wUwk8Y6oGQwRjudWK3/5mjZVJoY=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha1-kVP+mLuivVZaY63ZQ21vDX+EaP8=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -121,6 +984,33 @@
       "version": "14.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
       "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha1-/IwoJeTtIUJHO0qBBk5uCBRj0bM=",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha1-IPGClPeX8iCbX2XI47XI6CYdEnw=",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha1-JqrZjdLCo45CEIbqmtQrnlFkKXc=",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha1-O5ziSJkZ2eT+pDm3aRarw0st8Sk=",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -207,17 +1097,48 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o=",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -237,6 +1158,23 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+          "dev": true
+        }
+      }
+    },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -250,6 +1188,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -272,6 +1220,83 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "babel-jest": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/babel-jest/-/babel-jest-27.0.6.tgz",
+      "integrity": "sha1-6ZxuBXfaJlURjjYItodhpaab0Ng=",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^27.0.6",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+      "integrity": "sha1-4VnM3Jr5XgtXDHW0Vzt8NNZx12U=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^4.0.0",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz",
+      "integrity": "sha1-98az12SvIctKKhq2hwEX294VtFY=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz",
+      "integrity": "sha1-kJ7wjp8kpGeXaL4vYKPfCFaEP50=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^27.0.6",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -298,10 +1323,56 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.16.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha1-15ASd6WojlVO0wWxg+ybDAj2b6I=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001248",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
+      "integrity": "sha1-JqtF40DxVepdopINrbdqUzy4684=",
       "dev": true
     },
     "chalk": {
@@ -355,6 +1426,47 @@
         }
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha1-KHbLlIpJh5e1I28AlbwFfQ3KOLY=",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
+      "integrity": "sha1-n4S6MkSlEvOlTlJ36O70xImGTkA=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha1-zCyOlPwYu9/+ZNZTRXDIpnOyf1k=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -370,11 +1482,35 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -387,6 +1523,40 @@
         "which": "^2.0.1"
       }
     },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
+          "dev": true
+        }
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -396,10 +1566,46 @@
         "ms": "2.1.2"
       }
     },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha1-2MOkRKnGd0umDKatcmHDqU/V54M=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha1-MwXLLlWgM5JAVGlcxmAZ/X+OVyM=",
       "dev": true
     },
     "dir-glob": {
@@ -420,6 +1626,35 @@
         "esutils": "^2.0.2"
       }
     },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
+          "dev": true
+        }
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.791",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/electron-to-chromium/-/electron-to-chromium-1.3.791.tgz",
+      "integrity": "sha1-448yX/IkcL3P80QJ1YwLr5wuPpM=",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.8.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/emittery/-/emittery-0.8.1.tgz",
+      "integrity": "sha1-uyPMhtA7MKp1p/c0gZ3uLhunCGA=",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -435,11 +1670,77 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
     },
     "eslint": {
       "version": "7.19.0",
@@ -603,6 +1904,51 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expect": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/expect/-/expect-27.0.6.tgz",
+      "integrity": "sha1-pNdPviciLHGP/2jvSdeOJqj9TAU=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "ansi-styles": "^5.0.0",
+        "jest-get-type": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-regex-util": "^27.0.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -644,6 +1990,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
@@ -662,6 +2017,16 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -678,16 +2043,64 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true
     },
     "glob": {
@@ -736,11 +2149,77 @@
         "slash": "^3.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
       "version": "5.1.8",
@@ -756,6 +2235,16 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-local": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha1-qM/QQx0d5KIZlwPQA+PmI2T6bbY=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
       }
     },
     "imurmurhash": {
@@ -780,6 +2269,24 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-ci": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-ci/-/is-ci-3.0.0.tgz",
+      "integrity": "sha1-x+e+PJ2O730PoUQ5C9HkuI3EyZQ=",
+      "dev": true,
+      "requires": {
+        "ci-info": "^3.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.5.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha1-91SENhfHC/0pt72HMnQAzaXBhJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -790,6 +2297,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
     "is-glob": {
@@ -807,11 +2320,656 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha1-9ZRKN8cLVQsCp4pcOyBVsoDOyOw=",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha1-dXQ85tlruG3H7kNSz2Nmoj8LGtk=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha1-1ZMhDlAAaDdQywn8BkTktuJ/1Ts=",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest/-/jest-27.0.6.tgz",
+      "integrity": "sha1-EFF7KmKPBAkIf79HPbRHd9egRQU=",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^27.0.6",
+        "import-local": "^3.0.2",
+        "jest-cli": "^27.0.6"
+      },
+      "dependencies": {
+        "jest-cli": {
+          "version": "27.0.6",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-cli/-/jest-cli-27.0.6.tgz",
+          "integrity": "sha1-0CHl9NhtaiEkUNTHuGyyGfHmhk8=",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^27.0.6",
+            "@jest/test-result": "^27.0.6",
+            "@jest/types": "^27.0.6",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "jest-config": "^27.0.6",
+            "jest-util": "^27.0.6",
+            "jest-validate": "^27.0.6",
+            "prompts": "^2.0.1",
+            "yargs": "^16.0.3"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-changed-files/-/jest-changed-files-27.0.6.tgz",
+      "integrity": "sha1-vtYYP83qiihUguO1Cpp3EtSaeos=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "execa": "^5.0.0",
+        "throat": "^6.0.1"
+      }
+    },
+    "jest-circus": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-circus/-/jest-circus-27.0.6.tgz",
+      "integrity": "sha1-3U3xfEaX22osIyqq1OnOxmaSZmg=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^27.0.6",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3",
+        "throat": "^6.0.1"
+      }
+    },
+    "jest-config": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-config/-/jest-config-27.0.6.tgz",
+      "integrity": "sha1-EZ+xDxSbpj2cUGIbqk8fF5UAJ38=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "babel-jest": "^27.0.6",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^3.0.0",
+        "jest-circus": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-jasmine2": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runner": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.0.6"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-diff/-/jest-diff-27.0.6.tgz",
+      "integrity": "sha1-SnoZ7m8ErXDg4ziPNYKTlKRMe14=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
+      }
+    },
+    "jest-docblock": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-docblock/-/jest-docblock-27.0.6.tgz",
+      "integrity": "sha1-zHgmas9/5pPKRiy72g6k5jnk5fM=",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-each/-/jest-each-27.0.6.tgz",
+      "integrity": "sha1-zuEXBxsEBgFY3I2aZtxQrUDvRTs=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz",
+      "integrity": "sha1-9mQmxMmVCAfQqfIJxZDOVE9zKR8=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jsdom": "^16.6.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-environment-node/-/jest-environment-node-27.0.6.tgz",
+      "integrity": "sha1-pmmbfOtS6NaBOLmAiwxATlBfPgc=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "jest-mock": "^27.0.6",
+        "jest-util": "^27.0.6"
+      }
+    },
+    "jest-get-type": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha1-DrXH91WFQnnOm2ip8aQSL2kEfP4=",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-haste-map/-/jest-haste-map-27.0.6.tgz",
+      "integrity": "sha1-RoOk5o9uyqdCMWedyiNyeVYsjcc=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^27.0.6",
+        "jest-serializer": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz",
+      "integrity": "sha1-/VCantPZK9bttop3n0c4sQBlWzc=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^27.0.6",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "pretty-format": "^27.0.6",
+        "throat": "^6.0.1"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz",
+      "integrity": "sha1-VFhUJ1+FRQ1O9Lj+MFyiomRQRQ8=",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz",
+      "integrity": "sha1-Ko2h6GxiCzlFn0NS6qJV8NQ+Oak=",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.0.6"
+      }
+    },
+    "jest-message-util": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-message-util/-/jest-message-util-27.0.6.tgz",
+      "integrity": "sha1-FYvN9HhXBkktFko5q8pqFNpauLU=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^27.0.6",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^27.0.6",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-mock/-/jest-mock-27.0.6.tgz",
+      "integrity": "sha1-Dv3UCFE5gwe6FneHKPbTTVg+NGc=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "@types/node": "*"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw=",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-regex-util/-/jest-regex-util-27.0.6.tgz",
+      "integrity": "sha1-AuESCCk1rpSc5dE7JnXbPYyH2cU=",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-resolve/-/jest-resolve-27.0.6.tgz",
+      "integrity": "sha1-6Q9DbdT4+/U/WKkcQjRIZPjlW/8=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "chalk": "^4.0.0",
+        "escalade": "^3.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "resolve": "^1.20.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz",
+      "integrity": "sha1-PmGeDvORw+z89u9AViB6PSvjJp8=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-snapshot": "^27.0.6"
+      }
+    },
+    "jest-runner": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-runner/-/jest-runner-27.0.6.tgz",
+      "integrity": "sha1-EyX0UFVTkiK7xyVqaXbpk60vlSA=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.8.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-docblock": "^27.0.6",
+        "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-node": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-leak-detector": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-runtime": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-worker": "^27.0.6",
+        "source-map-support": "^0.5.6",
+        "throat": "^6.0.1"
+      }
+    },
+    "jest-runtime": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-runtime/-/jest-runtime-27.0.6.tgz",
+      "integrity": "sha1-RYd8/NOGr91PMX3vVR/DaXlMJ8k=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^27.0.6",
+        "@jest/environment": "^27.0.6",
+        "@jest/fake-timers": "^27.0.6",
+        "@jest/globals": "^27.0.6",
+        "@jest/source-map": "^27.0.6",
+        "@jest/test-result": "^27.0.6",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-mock": "^27.0.6",
+        "jest-regex-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-snapshot": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "jest-validate": "^27.0.6",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^16.0.3"
+      }
+    },
+    "jest-serializer": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-serializer/-/jest-serializer-27.0.6.tgz",
+      "integrity": "sha1-k6bHTgEyuBotVGIyUcRsSYu1vsE=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "graceful-fs": "^4.2.4"
+      }
+    },
+    "jest-snapshot": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-snapshot/-/jest-snapshot-27.0.6.tgz",
+      "integrity": "sha1-9OayCL0ukuiINE148PZQvP8FpL8=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.2",
+        "@babel/generator": "^7.7.2",
+        "@babel/parser": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.0.0",
+        "@jest/transform": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^27.0.6",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "jest-haste-map": "^27.0.6",
+        "jest-matcher-utils": "^27.0.6",
+        "jest-message-util": "^27.0.6",
+        "jest-resolve": "^27.0.6",
+        "jest-util": "^27.0.6",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^27.0.6",
+        "semver": "^7.3.2"
+      }
+    },
+    "jest-util": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-util/-/jest-util-27.0.6.tgz",
+      "integrity": "sha1-6OBO7BWd4vTV9X95XfnNwJHlApc=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^3.0.0",
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+          "dev": true
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-validate/-/jest-validate-27.0.6.tgz",
+      "integrity": "sha1-kwpSfHqVGSffJp9DstwjJiRX4qY=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^27.0.6",
+        "leven": "^3.1.0",
+        "pretty-format": "^27.0.6"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-watcher/-/jest-watcher-27.0.6.tgz",
+      "integrity": "sha1-iVJvf57fHqxOS+mJvLbexriHjZw=",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^27.0.6",
+        "@jest/types": "^27.0.6",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "jest-util": "^27.0.6",
+        "string-length": "^4.0.1"
+      }
+    },
+    "jest-worker": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jest-worker/-/jest-worker-27.0.6.tgz",
+      "integrity": "sha1-pf2x4UrTTrIoz+Fi2fcpzb+iiu0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -829,6 +2987,55 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdom": {
+      "version": "16.6.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jsdom/-/jsdom-16.6.0.tgz",
+      "integrity": "sha1-95s3hmggZUkqPaamCkaV2pg4Baw=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.5",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.4.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/acorn/-/acorn-8.4.1.tgz",
+          "integrity": "sha1-VsNiUfx8q8cJatwY8Fr+gUMhoow=",
+          "dev": true
+        }
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -841,6 +3048,27 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -849,6 +3077,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
@@ -866,6 +3103,38 @@
         "yallist": "^4.0.0"
       }
     },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -882,6 +3151,27 @@
         "picomatch": "^2.0.5"
       }
     },
+    "mime-db": {
+      "version": "1.49.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime-db/-/mime-db-1.49.0.tgz",
+      "integrity": "sha1-89/eYMmenPO8lwHWh3ePU3ABy+0=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.32",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mime-types/-/mime-types-2.1.32.tgz",
+      "integrity": "sha1-HQDonn3n/gIAjbYQAdngKFJnD9U=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.49.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -890,6 +3180,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -903,6 +3199,45 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.73",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/node-releases/-/node-releases-1.1.73.tgz",
+      "integrity": "sha1-3U6B3dUnf/hGuAtSu0DEnt96eyA=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -910,6 +3245,15 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
@@ -926,6 +3270,36 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha1-EFqwNXznKyAqiouUkzZyZXteKpo=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -934,6 +3308,18 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -945,6 +3331,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true
     },
     "path-type": {
@@ -959,16 +3351,70 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "pretty-format": {
+      "version": "27.0.6",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/pretty-format/-/pretty-format-27.0.6.tgz",
+      "integrity": "sha1-q3cMR7LG+JOiGu/Fe3XaY+9JoR8=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.0.6",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+          "dev": true
+        }
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prompts": {
+      "version": "2.4.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/prompts/-/prompts-2.4.1.tgz",
+      "integrity": "sha1-vv07EZW6BS+f0v3opIbE6C7nf2E=",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
       "dev": true
     },
     "punycode": {
@@ -977,10 +3423,22 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
+      "dev": true
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-from-string": {
@@ -988,6 +3446,33 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+          "dev": true
+        }
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -1016,6 +3501,27 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
     "semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -1038,6 +3544,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true
     },
     "slash": {
@@ -1083,11 +3601,54 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha1-zV8DASb/EWt4zLPAJ/4wJxO2Enc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+          "dev": true
+        }
+      }
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "string-width": {
       "version": "4.2.0",
@@ -1109,6 +3670,18 @@
         "ansi-regex": "^5.0.0"
       }
     },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1123,6 +3696,39 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha1-T3e0JIh2WJF3S3DHm6vYf5vVlLs=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
+      "dev": true
     },
     "table": {
       "version": "6.0.7",
@@ -1156,10 +3762,49 @@
         }
       }
     },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/throat/-/throat-6.0.1.tgz",
+      "integrity": "sha1-1RT+2tlXQMEsLX/HDqhj61Gt43U=",
+      "dev": true
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-regex-range": {
@@ -1169,6 +3814,26 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha1-+oeqgcpdWUHajL8fm3SdyWmk4kA=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
       }
     },
     "tslib": {
@@ -1195,16 +3860,37 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true
     },
     "uri-js": {
@@ -1222,6 +3908,84 @@
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
+    "v8-to-istanbul": {
+      "version": "8.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
+      "integrity": "sha1-QinyqZ42fz8Bj6HVwrjsaEZnxpw=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        }
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha1-ZWp45RD/jzk3vAvL6fXArDWUG3c=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1237,16 +4001,110 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.5.3",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha1-Fgg1tjx9l7+rQY/BuKn87SrAGnQ=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://artifactory.palantir.build/artifactory/api/npm/all-npm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
 		"eslint-rule-composer": "^0.3.0"
 	},
 	"devDependencies": {
-		"@types/eslint": "^7.2.4",
-		"@types/node": "^14.14.2",
 		"@typescript-eslint/eslint-plugin": "^4.14.2",
 		"@typescript-eslint/parser": "^4.14.2",
 		"eslint": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -13,16 +13,20 @@
 	],
 	"author": "Mikkel Holmer Pedersen",
 	"main": "lib/index.js",
+	"scripts": {
+		"test": "jest"
+	},
 	"dependencies": {
 		"eslint-rule-composer": "^0.3.0"
 	},
 	"devDependencies": {
-		"typescript": "^4.0.3",
-		"eslint": "^7.19.0",
+		"@types/eslint": "^7.2.4",
+		"@types/node": "^14.14.2",
 		"@typescript-eslint/eslint-plugin": "^4.14.2",
 		"@typescript-eslint/parser": "^4.14.2",
-		"@types/eslint": "^7.2.4",
-		"@types/node": "^14.14.2"
+		"eslint": "^7.19.0",
+		"jest": "^27.0.6",
+		"typescript": "^4.0.3"
 	},
 	"engines": {
 		"node": ">=0.10.0"


### PR DESCRIPTION
## Fixes https://github.com/sweepline/eslint-plugin-unused-imports/issues/28

This PR fixes a bug where jsdocs get inadvertently deleted when:
  - the last import statement is unused
  - there are jsdocs between that last import statement and the next non-comment token

This PR also adds some tests to verify the code is correct!