### PR TITLE
Update @typescript-eslint/{parser,eslint-plugin} dependencies to ^7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Find and remove unused es6 module imports. It works by splitting up the `no-unus
 
 ## _Versions_
 
+* Version 4.x.x is for eslint 8 with @typescript-eslint/eslint-plugin 7
 * Version 3.x.x is for eslint 8 with @typescript-eslint/eslint-plugin 6
 * Version 2.x.x is for eslint 8 with @typescript-eslint/eslint-plugin 5
 * Version 1.x.x is for eslint 6 and 7.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "eslint-plugin-unused-imports",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "eslint-plugin-unused-imports",
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"eslint-rule-composer": "^0.3.0"
 			},
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^6.0.0",
-				"@typescript-eslint/parser": "^6.0.0",
+				"@typescript-eslint/eslint-plugin": "^7.0.0",
+				"@typescript-eslint/parser": "^7.0.0",
 				"eslint": "^8.0.1",
 				"jest": "^27.2.5"
 			},
@@ -21,7 +21,7 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^6.0.0",
+				"@typescript-eslint/eslint-plugin": "^7.0.0",
 				"eslint": "^8.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -615,18 +615,18 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-			"integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -647,22 +647,22 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-			"integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^1.2.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -683,9 +683,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -1236,9 +1236,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -1254,9 +1254,9 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+			"integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
 			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
@@ -1281,23 +1281,21 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.0.0.tgz",
-			"integrity": "sha512-xuv6ghKGoiq856Bww/yVYnXGsKa588kY3M0XK7uUW/3fJNNULKRfZfSBkMTSpqGG/8ZCXCadfh8G/z/B4aqS/A==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
+			"integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.0",
-				"@typescript-eslint/scope-manager": "6.0.0",
-				"@typescript-eslint/type-utils": "6.0.0",
-				"@typescript-eslint/utils": "6.0.0",
-				"@typescript-eslint/visitor-keys": "6.0.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "7.0.1",
+				"@typescript-eslint/type-utils": "7.0.1",
+				"@typescript-eslint/utils": "7.0.1",
+				"@typescript-eslint/visitor-keys": "7.0.1",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
 				"natural-compare": "^1.4.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.5.0",
+				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
@@ -1308,8 +1306,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -1318,15 +1316,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.0.0.tgz",
-			"integrity": "sha512-TNaufYSPrr1U8n+3xN+Yp9g31vQDJqhXzzPSHfQDLcaO4tU+mCfODPxCwf4H530zo7aUBE3QIdxCXamEnG04Tg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
+			"integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.0.0",
-				"@typescript-eslint/types": "6.0.0",
-				"@typescript-eslint/typescript-estree": "6.0.0",
-				"@typescript-eslint/visitor-keys": "6.0.0",
+				"@typescript-eslint/scope-manager": "7.0.1",
+				"@typescript-eslint/types": "7.0.1",
+				"@typescript-eslint/typescript-estree": "7.0.1",
+				"@typescript-eslint/visitor-keys": "7.0.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1337,7 +1335,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -1346,13 +1344,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.0.0.tgz",
-			"integrity": "sha512-o4q0KHlgCZTqjuaZ25nw5W57NeykZT9LiMEG4do/ovwvOcPnDO1BI5BQdCsUkjxFyrCL0cSzLjvIMfR9uo7cWg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+			"integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.0.0",
-				"@typescript-eslint/visitor-keys": "6.0.0"
+				"@typescript-eslint/types": "7.0.1",
+				"@typescript-eslint/visitor-keys": "7.0.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1363,13 +1361,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.0.0.tgz",
-			"integrity": "sha512-ah6LJvLgkoZ/pyJ9GAdFkzeuMZ8goV6BH7eC9FPmojrnX9yNCIsfjB+zYcnex28YO3RFvBkV6rMV6WpIqkPvoQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
+			"integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.0.0",
-				"@typescript-eslint/utils": "6.0.0",
+				"@typescript-eslint/typescript-estree": "7.0.1",
+				"@typescript-eslint/utils": "7.0.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -1381,7 +1379,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -1390,9 +1388,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.0.0.tgz",
-			"integrity": "sha512-Zk9KDggyZM6tj0AJWYYKgF0yQyrcnievdhG0g5FqyU3Y2DRxJn4yWY21sJC0QKBckbsdKKjYDV2yVrrEvuTgxg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+			"integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1403,17 +1401,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.0.0.tgz",
-			"integrity": "sha512-2zq4O7P6YCQADfmJ5OTDQTP3ktajnXIRrYAtHM9ofto/CJZV3QfJ89GEaM2BNGeSr1KgmBuLhEkz5FBkS2RQhQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+			"integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.0.0",
-				"@typescript-eslint/visitor-keys": "6.0.0",
+				"@typescript-eslint/types": "7.0.1",
+				"@typescript-eslint/visitor-keys": "7.0.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.5.0",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
@@ -1429,20 +1428,43 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.0.0.tgz",
-			"integrity": "sha512-SOr6l4NB6HE4H/ktz0JVVWNXqCJTOo/mHnvIte1ZhBQ0Cvd04x5uKZa3zT6tiodL06zf5xxdK8COiDvPnQ27JQ==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.3.0",
-				"@types/json-schema": "^7.0.11",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "6.0.0",
-				"@typescript-eslint/types": "6.0.0",
-				"@typescript-eslint/typescript-estree": "6.0.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.5.0"
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
+			"integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "7.0.1",
+				"@typescript-eslint/types": "7.0.1",
+				"@typescript-eslint/typescript-estree": "7.0.1",
+				"semver": "^7.5.4"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -1452,16 +1474,16 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.0.0.tgz",
-			"integrity": "sha512-cvJ63l8c0yXdeT5POHpL0Q1cZoRcmRKFCtSjNGJxPkcP571EfZMcNbzWAc7oK3D1dRzm/V5EwtkANTZxqvuuUA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+			"integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.0.0",
+				"@typescript-eslint/types": "7.0.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -1471,6 +1493,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
 		},
 		"node_modules/abab": {
 			"version": "2.0.6",
@@ -2212,37 +2240,29 @@
 				"source-map": "~0.6.1"
 			}
 		},
-		"node_modules/escodegen/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/eslint": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-			"integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.1.0",
-				"@eslint/js": "8.44.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.56.0",
+				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.0",
-				"eslint-visitor-keys": "^3.4.1",
-				"espree": "^9.6.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2252,7 +2272,6 @@
 				"globals": "^13.19.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
@@ -2264,7 +2283,6 @@
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -2286,34 +2304,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -2326,19 +2319,22 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
-				"node": ">=4.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-			"integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
@@ -2377,15 +2373,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2398,19 +2385,10 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -2479,9 +2457,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-			"integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -2707,9 +2685,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -2745,12 +2723,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
 		"node_modules/graphemer": {
@@ -4002,12 +3974,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4858,12 +4824,12 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-			"integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
 			"dev": true,
 			"engines": {
-				"node": ">=16.13.0"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
@@ -4912,9 +4878,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"peer": true,
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-unused-imports",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "Report and remove unused es6 modules",
 	"keywords": [
 		"eslint",
@@ -17,7 +17,7 @@
 		"test": "jest"
 	},
 	"peerDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.0.0",
+		"@typescript-eslint/eslint-plugin": "^7.0.0",
 		"eslint": "^8.0.0"
 	},
 	"peerDependenciesMeta": {
@@ -29,8 +29,8 @@
 		"eslint-rule-composer": "^0.3.0"
 	},
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.0.0",
-		"@typescript-eslint/parser": "^6.0.0",
+		"@typescript-eslint/eslint-plugin": "^7.0.0",
+		"@typescript-eslint/parser": "^7.0.0",
 		"eslint": "^8.0.1",
 		"jest": "^27.2.5"
 	},


### PR DESCRIPTION
Supported [typescript-eslint v7](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7).  I confirmed that `npm run test` was executed and passed.