### PR TITLE
Fix ESLint configuration instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ npm install eslint-plugin-unused-imports --save-dev
 
 ## Usage
 
-Add `unused-imports` to the plugins section of your `.eslintrc` configuration file.
+Add `unused-imports` to the plugins section of your `eslint.config.js` configuration file.
 
-```jsonc
+```js
 import unusedImports from "eslint-plugin-unused-imports";
 
 export default [{


### PR DESCRIPTION
Hi, The example code snippet in the README Usage section uses the Flat Config format. 
This PR updates the README description to align with it.